### PR TITLE
feat: add doctrine repository layer and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Symfony application code sits in `src/` with domain models, controllers, and services following PSR-4 namespaces. Environment and service wiring live in `config/`. HTTP entrypoints and assets served via `public/`. Twig email templates in `templates/`. Tests and fixtures under `tests/`. Docker orchestration and TLS utilities live in `docker/` and `scripts/`. Performance artefacts are tracked in `load-tests/` and `performance-results/`. Legacy guidance remains in `.kiro/steering/` and `.kiro/specs/`; AI agents should reference these documents when planning work even though formal Kiro workflows are retired.
+
+## Build, Test, and Development Commands
+`make setup` provisions directories, SSL certs, and the shared Docker network. `make build` builds the PHP, Traefik, PostgreSQL, and Redis containers; rerun whenever Dockerfiles change. `make start` boots the traditional stack at `https://traditional.ecommerce.localhost`. Run `make install` for composer deps, and `make migrate` or `make db-create` to manage schema. Use `make stop` and `make clean` to tear down environments.
+
+## Coding Style & Naming Conventions
+PHP code follows Symfony + PHP 8.4 rules enforced by `make cs-check`/`make cs-fix` (PHP-CS-Fixer). Keep strict types enabled, prefer constructor property promotion, and order imports alphabetically by class/function/const. Use 4-space indentation, PascalCase classes, camelCase methods, and descriptive service IDs. Configuration files should mirror feature-based directory names.
+
+## Testing Guidelines
+Unit and feature tests belong in `tests/` with filenames ending in `Test.php` and PHPUnit namespaces matching their directory. Execute the suite with `make test`, which runs `vendor/bin/phpunit` inside the PHP-FPM container. Include regression coverage for new endpoints and update fixtures as needed. For performance phases, trigger Artillery scenarios with `make load-test` and capture results in `performance-results/`.
+
+## Commit & Pull Request Guidelines
+Follow conventional commit prefixes observed in history (`feat:`, `fix:`, `chore:`) and keep subjects under 72 characters. Describe context, intent, and any spec links in the body. Pull requests should summarize changes, reference steering documents or issues, note how tests were executed, and attach relevant API responses or screenshots when behaviour shifts. Keep PRs scoped to a single feature or fix to ease agent review.

--- a/src/Domain/Entity/Order.php
+++ b/src/Domain/Entity/Order.php
@@ -16,6 +16,7 @@ use App\Infrastructure\Doctrine\Type\EmailType;
 use App\Infrastructure\Doctrine\Type\MoneyType;
 use App\Infrastructure\Doctrine\Type\OrderNumberType;
 use App\Infrastructure\Doctrine\Type\PhoneType;
+use App\Infrastructure\Repository\OrderRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -28,7 +29,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Represents e-commerce orders with support for both authenticated users
  * and guest customers. Guest information is stored directly in the order.
  */
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: OrderRepository::class)]
 #[ORM\Table(name: 'orders')]
 #[ORM\HasLifecycleCallbacks]
 final class Order extends BaseEntity implements ValidatableInterface

--- a/src/Domain/Entity/OrderItem.php
+++ b/src/Domain/Entity/OrderItem.php
@@ -63,7 +63,7 @@ final class OrderItem extends BaseEntity implements ValidatableInterface
         $this->product = $product;
         $this->productName = $product->getName();
         $this->productSku = $product->getSku();
-        
+
         if ($unitPrice === null) {
             $this->unitPrice = $product->getPrice();
         } elseif ($unitPrice instanceof Money) {
@@ -71,7 +71,7 @@ final class OrderItem extends BaseEntity implements ValidatableInterface
         } else {
             $this->unitPrice = new Money($unitPrice, $product->getPrice()->getCurrency());
         }
-        
+
         $this->quantity = $quantity;
         $this->calculateTotalPrice();
     }
@@ -109,32 +109,43 @@ final class OrderItem extends BaseEntity implements ValidatableInterface
         return $this;
     }
 
-    public function getProductSku(): ?string
+    public function getProductSku(): ?ProductSku
     {
         return $this->productSku;
     }
 
-    public function setProductSku(?string $productSku): static
+    public function setProductSku(ProductSku|string|null $productSku): static
     {
-        $this->productSku = $productSku;
+        if ($productSku === null) {
+            $this->productSku = null;
+        } elseif ($productSku instanceof ProductSku) {
+            $this->productSku = $productSku;
+        } else {
+            $this->productSku = new ProductSku($productSku);
+        }
         return $this;
     }
 
-    public function getUnitPrice(): string
+    public function getUnitPrice(): Money
     {
         return $this->unitPrice;
     }
 
-    public function setUnitPrice(string $unitPrice): static
+    public function setUnitPrice(Money|string $unitPrice): static
     {
-        $this->unitPrice = $unitPrice;
+        if ($unitPrice instanceof Money) {
+            $this->unitPrice = $unitPrice;
+        } else {
+            $this->unitPrice = new Money($unitPrice, $this->unitPrice->getCurrency());
+        }
+
         $this->calculateTotalPrice();
         return $this;
     }
 
     public function getUnitPriceAsFloat(): float
     {
-        return (float) $this->unitPrice;
+        return $this->unitPrice->getAmountAsFloat();
     }
 
     public function getQuantity(): int
@@ -149,26 +160,29 @@ final class OrderItem extends BaseEntity implements ValidatableInterface
         return $this;
     }
 
-    public function getTotalPrice(): string
+    public function getTotalPrice(): Money
     {
         return $this->totalPrice;
     }
 
-    public function setTotalPrice(string $totalPrice): static
+    public function setTotalPrice(Money|string $totalPrice): static
     {
-        $this->totalPrice = $totalPrice;
+        if ($totalPrice instanceof Money) {
+            $this->totalPrice = $totalPrice;
+        } else {
+            $this->totalPrice = new Money($totalPrice, $this->unitPrice->getCurrency());
+        }
         return $this;
     }
 
     public function getTotalPriceAsFloat(): float
     {
-        return (float) $this->totalPrice;
+        return $this->totalPrice->getAmountAsFloat();
     }
 
     public function calculateTotalPrice(): static
     {
-        $total = $this->getUnitPriceAsFloat() * $this->quantity;
-        $this->totalPrice = number_format($total, 2, '.', '');
+        $this->totalPrice = $this->unitPrice->multiply((float) $this->quantity);
         return $this;
     }
 

--- a/src/Domain/Entity/Product.php
+++ b/src/Domain/Entity/Product.php
@@ -11,6 +11,7 @@ use App\Domain\ValueObject\Slug;
 use App\Infrastructure\Doctrine\Type\MoneyType;
 use App\Infrastructure\Doctrine\Type\ProductSkuType;
 use App\Infrastructure\Doctrine\Type\SlugType;
+use App\Infrastructure\Repository\ProductRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -21,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Represents e-commerce products with flexible attributes and variants
  * stored in PostgreSQL JSONB columns for optimal performance.
  */
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: ProductRepository::class)]
 #[ORM\Table(name: 'products')]
 #[ORM\HasLifecycleCallbacks]
 final class Product extends BaseEntity implements ValidatableInterface

--- a/src/Domain/Entity/User.php
+++ b/src/Domain/Entity/User.php
@@ -9,6 +9,7 @@ use App\Domain\ValueObject\PersonName;
 use App\Domain\ValueObject\Phone;
 use App\Infrastructure\Doctrine\Type\EmailType;
 use App\Infrastructure\Doctrine\Type\PhoneType;
+use App\Infrastructure\Repository\UserRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
@@ -21,7 +22,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Implements Symfony security interfaces for authentication
  * and provides role-based access control.
  */
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\Table(name: 'users')]
 #[ORM\HasLifecycleCallbacks]
 

--- a/src/Domain/Repository/OrderRepositoryInterface.php
+++ b/src/Domain/Repository/OrderRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Repository;
+
+use App\Domain\Entity\Order;
+use App\Domain\Entity\User;
+use App\Domain\ValueObject\Email;
+use App\Domain\ValueObject\OrderNumber;
+
+interface OrderRepositoryInterface extends RepositoryInterface
+{
+    public function findByOrderNumber(OrderNumber|string $orderNumber): ?Order;
+
+    /** @return list<Order> */
+    public function findRecentOrdersForUser(User $user, int $limit = 10): array;
+
+    /** @return list<Order> */
+    public function findOrdersForGuestEmail(Email|string $email, int $limit = 10): array;
+
+    /** @return list<Order> */
+    public function findOpenOrders(): array;
+}

--- a/src/Domain/Repository/ProductRepositoryInterface.php
+++ b/src/Domain/Repository/ProductRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Repository;
+
+use App\Domain\Entity\Product;
+
+interface ProductRepositoryInterface extends RepositoryInterface
+{
+    public function findOneBySlug(string $slug): ?Product;
+
+    /** @return list<Product> */
+    public function searchProducts(?string $term, ?string $categorySlug, int $page = 1, int $limit = 20): array;
+
+    public function countSearchResults(?string $term, ?string $categorySlug): int;
+
+    /** @return list<Product> */
+    public function findFeaturedProducts(int $limit = 8): array;
+}

--- a/src/Domain/Repository/UserRepositoryInterface.php
+++ b/src/Domain/Repository/UserRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Repository;
+
+use App\Domain\Entity\User;
+use App\Domain\ValueObject\Email;
+
+interface UserRepositoryInterface extends RepositoryInterface
+{
+    public function findActiveUserByEmail(Email|string $email): ?User;
+
+    /** @return list<User> */
+    public function searchCustomers(?string $term, int $limit = 20): array;
+
+    /** @return list<User> */
+    public function findAdmins(): array;
+}

--- a/src/Domain/Type/UuidType.php
+++ b/src/Domain/Type/UuidType.php
@@ -24,7 +24,11 @@ final class UuidType extends GuidType
 
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
     {
-        return 'UUID';
+        if ($platform->getName() === 'postgresql') {
+            return 'UUID';
+        }
+
+        return parent::getSQLDeclaration($column, $platform);
     }
 
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool

--- a/src/Domain/ValueObject/PersonName.php
+++ b/src/Domain/ValueObject/PersonName.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\ValueObject;
 
+use Doctrine\ORM\Mapping as ORM;
 use InvalidArgumentException;
 
 /**
@@ -12,9 +13,13 @@ use InvalidArgumentException;
  * Encapsulates person name validation and behavior according to DDD principles.
  * Ensures names are always in a valid state.
  */
+#[ORM\Embeddable]
 final readonly class PersonName
 {
+    #[ORM\Column(type: 'string', length: 100, nullable: true)]
     private string $firstName;
+
+    #[ORM\Column(type: 'string', length: 100, nullable: true)]
     private string $lastName;
 
     public function __construct(string $firstName, string $lastName)

--- a/src/Infrastructure/Repository/AbstractRepository.php
+++ b/src/Infrastructure/Repository/AbstractRepository.php
@@ -38,7 +38,7 @@ abstract class AbstractRepository extends ServiceEntityRepository implements Rep
      */
     public function findByCriteria(array $criteria, array $sorting = []): array
     {
-        $qb = $this->createQueryBuilder('e');
+        $qb = $this->createQueryBuilder('entity');
         $this->applyCriteria($qb, $criteria);
         $this->applySorting($qb, $sorting);
 
@@ -47,7 +47,7 @@ abstract class AbstractRepository extends ServiceEntityRepository implements Rep
 
     public function findOneByCriteria(array $criteria, array $sorting = [])
     {
-        $qb = $this->createQueryBuilder('e');
+        $qb = $this->createQueryBuilder('entity');
         $this->applyCriteria($qb, $criteria);
         $this->applySorting($qb, $sorting);
 
@@ -57,7 +57,7 @@ abstract class AbstractRepository extends ServiceEntityRepository implements Rep
     /**
      * Apply exact-match filters to a query builder
      */
-    protected function applyCriteria(QueryBuilder $qb, array $criteria, string $alias = 'e'): void
+    protected function applyCriteria(QueryBuilder $qb, array $criteria, string $alias = 'entity'): void
     {
         foreach ($criteria as $field => $value) {
             if ($value === null) {
@@ -80,7 +80,7 @@ abstract class AbstractRepository extends ServiceEntityRepository implements Rep
     /**
      * Apply order by clauses from an array of field => direction
      */
-    protected function applySorting(QueryBuilder $qb, array $sorting, string $alias = 'e'): void
+    protected function applySorting(QueryBuilder $qb, array $sorting, string $alias = 'entity'): void
     {
         foreach ($sorting as $field => $direction) {
             $direction = strtoupper((string) $direction) === 'DESC' ? 'DESC' : 'ASC';

--- a/src/Infrastructure/Repository/OrderRepository.php
+++ b/src/Infrastructure/Repository/OrderRepository.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Repository;
+
+use App\Domain\Entity\Order;
+use App\Domain\Entity\User;
+use App\Domain\Repository\OrderRepositoryInterface;
+use App\Domain\ValueObject\Email;
+use App\Domain\ValueObject\OrderNumber;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class OrderRepository extends AbstractRepository implements OrderRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Order::class);
+    }
+
+    public function findByOrderNumber(OrderNumber|string $orderNumber): ?Order
+    {
+        $value = $orderNumber instanceof OrderNumber ? $orderNumber->getValue() : (string) $orderNumber;
+
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.orderNumber = :orderNumber')
+            ->setParameter('orderNumber', $value)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findRecentOrdersForUser(User $user, int $limit = 10): array
+    {
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.customer = :customer')
+            ->setParameter('customer', $user)
+            ->orderBy('o.id', 'DESC')
+            ->setMaxResults(max(1, $limit))
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findOrdersForGuestEmail(Email|string $email, int $limit = 10): array
+    {
+        $value = $email instanceof Email ? $email->getValue() : (string) $email;
+
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.guestEmail = :guestEmail')
+            ->setParameter('guestEmail', $value)
+            ->orderBy('o.id', 'DESC')
+            ->setMaxResults(max(1, $limit))
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findOpenOrders(): array
+    {
+        $openStatuses = [
+            Order::STATUS_PENDING,
+            Order::STATUS_CONFIRMED,
+            Order::STATUS_PROCESSING,
+            Order::STATUS_SHIPPED,
+        ];
+
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.status IN (:statuses)')
+            ->setParameter('statuses', $openStatuses)
+            ->orderBy('o.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Infrastructure/Repository/OrderRepository.php
+++ b/src/Infrastructure/Repository/OrderRepository.php
@@ -22,8 +22,8 @@ final class OrderRepository extends AbstractRepository implements OrderRepositor
     {
         $value = $orderNumber instanceof OrderNumber ? $orderNumber->getValue() : (string) $orderNumber;
 
-        return $this->createQueryBuilder('o')
-            ->andWhere('o.orderNumber = :orderNumber')
+        return $this->createQueryBuilder('orderRecord')
+            ->andWhere('orderRecord.orderNumber = :orderNumber')
             ->setParameter('orderNumber', $value)
             ->getQuery()
             ->getOneOrNullResult();
@@ -31,10 +31,10 @@ final class OrderRepository extends AbstractRepository implements OrderRepositor
 
     public function findRecentOrdersForUser(User $user, int $limit = 10): array
     {
-        return $this->createQueryBuilder('o')
-            ->andWhere('o.customer = :customer')
+        return $this->createQueryBuilder('orderRecord')
+            ->andWhere('orderRecord.customer = :customer')
             ->setParameter('customer', $user)
-            ->orderBy('o.id', 'DESC')
+            ->orderBy('orderRecord.id', 'DESC')
             ->setMaxResults(max(1, $limit))
             ->getQuery()
             ->getResult();
@@ -44,10 +44,10 @@ final class OrderRepository extends AbstractRepository implements OrderRepositor
     {
         $value = $email instanceof Email ? $email->getValue() : (string) $email;
 
-        return $this->createQueryBuilder('o')
-            ->andWhere('o.guestEmail = :guestEmail')
+        return $this->createQueryBuilder('orderRecord')
+            ->andWhere('orderRecord.guestEmail = :guestEmail')
             ->setParameter('guestEmail', $value)
-            ->orderBy('o.id', 'DESC')
+            ->orderBy('orderRecord.id', 'DESC')
             ->setMaxResults(max(1, $limit))
             ->getQuery()
             ->getResult();
@@ -62,10 +62,10 @@ final class OrderRepository extends AbstractRepository implements OrderRepositor
             Order::STATUS_SHIPPED,
         ];
 
-        return $this->createQueryBuilder('o')
-            ->andWhere('o.status IN (:statuses)')
+        return $this->createQueryBuilder('orderRecord')
+            ->andWhere('orderRecord.status IN (:statuses)')
             ->setParameter('statuses', $openStatuses)
-            ->orderBy('o.id', 'ASC')
+            ->orderBy('orderRecord.id', 'ASC')
             ->getQuery()
             ->getResult();
     }

--- a/src/Infrastructure/Repository/ProductRepository.php
+++ b/src/Infrastructure/Repository/ProductRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Repository;
+
+use App\Domain\Entity\Product;
+use App\Domain\Repository\ProductRepositoryInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use function mb_strtolower;
+
+final class ProductRepository extends AbstractRepository implements ProductRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Product::class);
+    }
+
+    public function findOneBySlug(string $slug): ?Product
+    {
+        return $this->findOneBy(['slug' => $slug]);
+    }
+
+    public function searchProducts(?string $term, ?string $categorySlug, int $page = 1, int $limit = 20): array
+    {
+        $qb = $this->createQueryBuilder('p')
+            ->andWhere('p.isActive = :active')
+            ->setParameter('active', true)
+            ->orderBy('p.id', 'DESC');
+
+        if ($term !== null && $term !== '') {
+            $normalized = '%' . mb_strtolower($term) . '%';
+            $qb->andWhere('LOWER(p.name) LIKE :term OR LOWER(COALESCE(p.description, \'\')) LIKE :term OR LOWER(COALESCE(p.shortDescription, \'\')) LIKE :term')
+                ->setParameter('term', $normalized);
+        }
+
+        if ($categorySlug !== null && $categorySlug !== '') {
+            $qb->leftJoin('p.category', 'c')
+                ->andWhere('c.slug = :categorySlug')
+                ->setParameter('categorySlug', $categorySlug);
+        }
+
+        $this->applyPagination($qb, $page, $limit);
+
+        $products = $qb->getQuery()->getResult();
+
+        // Intentional N+1: accessing category details per product triggers extra queries in Phase 1
+        foreach ($products as $product) {
+            $product->getCategory()?->getName();
+        }
+
+        return $products;
+    }
+
+    public function countSearchResults(?string $term, ?string $categorySlug): int
+    {
+        $qb = $this->createQueryBuilder('p')
+            ->select('COUNT(p.id)')
+            ->andWhere('p.isActive = :active')
+            ->setParameter('active', true);
+
+        if ($term !== null && $term !== '') {
+            $normalized = '%' . mb_strtolower($term) . '%';
+            $qb->andWhere('LOWER(p.name) LIKE :term OR LOWER(COALESCE(p.description, \'\')) LIKE :term OR LOWER(COALESCE(p.shortDescription, \'\')) LIKE :term')
+                ->setParameter('term', $normalized);
+        }
+
+        if ($categorySlug !== null && $categorySlug !== '') {
+            $qb->leftJoin('p.category', 'c')
+                ->andWhere('c.slug = :categorySlug')
+                ->setParameter('categorySlug', $categorySlug);
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    public function findFeaturedProducts(int $limit = 8): array
+    {
+        $qb = $this->createQueryBuilder('p')
+            ->andWhere('p.isActive = :active')
+            ->andWhere('p.isFeatured = :featured')
+            ->setParameter('active', true)
+            ->setParameter('featured', true)
+            ->orderBy('p.id', 'DESC')
+            ->setMaxResults(max(1, $limit));
+
+        $products = $qb->getQuery()->getResult();
+
+        // Intentional N+1: keep phase-one eager loading story consistent
+        foreach ($products as $product) {
+            $product->getCategory()?->getName();
+        }
+
+        return $products;
+    }
+}

--- a/src/Infrastructure/Repository/ProductRepository.php
+++ b/src/Infrastructure/Repository/ProductRepository.php
@@ -23,20 +23,20 @@ final class ProductRepository extends AbstractRepository implements ProductRepos
 
     public function searchProducts(?string $term, ?string $categorySlug, int $page = 1, int $limit = 20): array
     {
-        $qb = $this->createQueryBuilder('p')
-            ->andWhere('p.isActive = :active')
+        $qb = $this->createQueryBuilder('product')
+            ->andWhere('product.isActive = :active')
             ->setParameter('active', true)
-            ->orderBy('p.id', 'DESC');
+            ->orderBy('product.id', 'DESC');
 
         if ($term !== null && $term !== '') {
             $normalized = '%' . mb_strtolower($term) . '%';
-            $qb->andWhere('LOWER(p.name) LIKE :term OR LOWER(COALESCE(p.description, \'\')) LIKE :term OR LOWER(COALESCE(p.shortDescription, \'\')) LIKE :term')
+            $qb->andWhere('LOWER(product.name) LIKE :term OR LOWER(COALESCE(product.description, \'\')) LIKE :term OR LOWER(COALESCE(product.shortDescription, \'\')) LIKE :term')
                 ->setParameter('term', $normalized);
         }
 
         if ($categorySlug !== null && $categorySlug !== '') {
-            $qb->leftJoin('p.category', 'c')
-                ->andWhere('c.slug = :categorySlug')
+            $qb->leftJoin('product.category', 'category')
+                ->andWhere('category.slug = :categorySlug')
                 ->setParameter('categorySlug', $categorySlug);
         }
 
@@ -54,20 +54,20 @@ final class ProductRepository extends AbstractRepository implements ProductRepos
 
     public function countSearchResults(?string $term, ?string $categorySlug): int
     {
-        $qb = $this->createQueryBuilder('p')
-            ->select('COUNT(p.id)')
-            ->andWhere('p.isActive = :active')
+        $qb = $this->createQueryBuilder('product')
+            ->select('COUNT(product.id)')
+            ->andWhere('product.isActive = :active')
             ->setParameter('active', true);
 
         if ($term !== null && $term !== '') {
             $normalized = '%' . mb_strtolower($term) . '%';
-            $qb->andWhere('LOWER(p.name) LIKE :term OR LOWER(COALESCE(p.description, \'\')) LIKE :term OR LOWER(COALESCE(p.shortDescription, \'\')) LIKE :term')
+            $qb->andWhere('LOWER(product.name) LIKE :term OR LOWER(COALESCE(product.description, \'\')) LIKE :term OR LOWER(COALESCE(product.shortDescription, \'\')) LIKE :term')
                 ->setParameter('term', $normalized);
         }
 
         if ($categorySlug !== null && $categorySlug !== '') {
-            $qb->leftJoin('p.category', 'c')
-                ->andWhere('c.slug = :categorySlug')
+            $qb->leftJoin('product.category', 'category')
+                ->andWhere('category.slug = :categorySlug')
                 ->setParameter('categorySlug', $categorySlug);
         }
 
@@ -76,12 +76,12 @@ final class ProductRepository extends AbstractRepository implements ProductRepos
 
     public function findFeaturedProducts(int $limit = 8): array
     {
-        $qb = $this->createQueryBuilder('p')
-            ->andWhere('p.isActive = :active')
-            ->andWhere('p.isFeatured = :featured')
+        $qb = $this->createQueryBuilder('product')
+            ->andWhere('product.isActive = :active')
+            ->andWhere('product.isFeatured = :featured')
             ->setParameter('active', true)
             ->setParameter('featured', true)
-            ->orderBy('p.id', 'DESC')
+            ->orderBy('product.id', 'DESC')
             ->setMaxResults(max(1, $limit));
 
         $products = $qb->getQuery()->getResult();

--- a/src/Infrastructure/Repository/UserRepository.php
+++ b/src/Infrastructure/Repository/UserRepository.php
@@ -21,10 +21,10 @@ final class UserRepository extends AbstractRepository implements UserRepositoryI
     {
         $value = $email instanceof Email ? $email->getValue() : (string) $email;
 
-        return $this->createQueryBuilder('u')
-            ->andWhere('LOWER(u.email) = :email')
+        return $this->createQueryBuilder('user')
+            ->andWhere('LOWER(user.email) = :email')
             ->setParameter('email', mb_strtolower($value))
-            ->andWhere('u.isActive = :active')
+            ->andWhere('user.isActive = :active')
             ->setParameter('active', true)
             ->getQuery()
             ->getOneOrNullResult();
@@ -32,15 +32,15 @@ final class UserRepository extends AbstractRepository implements UserRepositoryI
 
     public function searchCustomers(?string $term, int $limit = 20): array
     {
-        $qb = $this->createQueryBuilder('u')
-            ->andWhere('u.isActive = :active')
+        $qb = $this->createQueryBuilder('user')
+            ->andWhere('user.isActive = :active')
             ->setParameter('active', true)
-            ->orderBy('u.id', 'DESC')
+            ->orderBy('user.id', 'DESC')
             ->setMaxResults(max(1, $limit));
 
         if ($term !== null && $term !== '') {
             $normalized = '%' . mb_strtolower($term) . '%';
-            $qb->andWhere('LOWER(u.email) LIKE :term OR LOWER(u.name.firstName) LIKE :term OR LOWER(u.name.lastName) LIKE :term')
+            $qb->andWhere('LOWER(user.email) LIKE :term OR LOWER(user.name.firstName) LIKE :term OR LOWER(user.name.lastName) LIKE :term')
                 ->setParameter('term', $normalized);
         }
 
@@ -49,12 +49,12 @@ final class UserRepository extends AbstractRepository implements UserRepositoryI
 
     public function findAdmins(): array
     {
-        return $this->createQueryBuilder('u')
-            ->andWhere('u.roles LIKE :adminRole')
+        return $this->createQueryBuilder('user')
+            ->andWhere('user.roles LIKE :adminRole')
             ->setParameter('adminRole', '%ROLE_ADMIN%')
-            ->andWhere('u.isActive = :active')
+            ->andWhere('user.isActive = :active')
             ->setParameter('active', true)
-            ->orderBy('u.id', 'DESC')
+            ->orderBy('user.id', 'DESC')
             ->getQuery()
             ->getResult();
     }

--- a/src/Infrastructure/Repository/UserRepository.php
+++ b/src/Infrastructure/Repository/UserRepository.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Repository;
+
+use App\Domain\Entity\User;
+use App\Domain\Repository\UserRepositoryInterface;
+use App\Domain\ValueObject\Email;
+use Doctrine\Persistence\ManagerRegistry;
+use function mb_strtolower;
+
+final class UserRepository extends AbstractRepository implements UserRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+
+    public function findActiveUserByEmail(Email|string $email): ?User
+    {
+        $value = $email instanceof Email ? $email->getValue() : (string) $email;
+
+        return $this->createQueryBuilder('u')
+            ->andWhere('LOWER(u.email) = :email')
+            ->setParameter('email', mb_strtolower($value))
+            ->andWhere('u.isActive = :active')
+            ->setParameter('active', true)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function searchCustomers(?string $term, int $limit = 20): array
+    {
+        $qb = $this->createQueryBuilder('u')
+            ->andWhere('u.isActive = :active')
+            ->setParameter('active', true)
+            ->orderBy('u.id', 'DESC')
+            ->setMaxResults(max(1, $limit));
+
+        if ($term !== null && $term !== '') {
+            $normalized = '%' . mb_strtolower($term) . '%';
+            $qb->andWhere('LOWER(u.email) LIKE :term OR LOWER(u.name.firstName) LIKE :term OR LOWER(u.name.lastName) LIKE :term')
+                ->setParameter('term', $normalized);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function findAdmins(): array
+    {
+        return $this->createQueryBuilder('u')
+            ->andWhere('u.roles LIKE :adminRole')
+            ->setParameter('adminRole', '%ROLE_ADMIN%')
+            ->andWhere('u.isActive = :active')
+            ->setParameter('active', true)
+            ->orderBy('u.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/tests/Integration/Repository/OrderRepositoryTest.php
+++ b/tests/Integration/Repository/OrderRepositoryTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Domain\Entity\Category;
+use App\Domain\Entity\Order;
+use App\Domain\Entity\OrderItem;
+use App\Domain\Entity\Payment;
+use App\Domain\Entity\Product;
+use App\Domain\Entity\User;
+use App\Domain\ValueObject\Email;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\OrderNumber;
+use App\Domain\ValueObject\PersonName;
+use App\Domain\ValueObject\Slug;
+use App\Infrastructure\Repository\OrderRepository;
+use App\Tests\Support\Doctrine\DoctrineRepositoryTestCase;
+use DateTimeImmutable;
+use function random_int;
+
+final class OrderRepositoryTest extends DoctrineRepositoryTestCase
+{
+    private OrderRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new OrderRepository($this->managerRegistry);
+    }
+
+    protected function schemaClasses(): array
+    {
+        return [
+            Category::class,
+            Product::class,
+            User::class,
+            Order::class,
+            OrderItem::class,
+            Payment::class,
+        ];
+    }
+
+    public function testFindByOrderNumberReturnsOrder(): void
+    {
+        $user = $this->createUser('buyer@example.com');
+        $order = $this->createOrder('ORD-1001', $user);
+
+        $this->entityManager->flush();
+
+        $found = $this->repository->findByOrderNumber(new OrderNumber('ORD-1001'));
+
+        self::assertNotNull($found);
+        self::assertSame($order->getId(), $found->getId());
+    }
+
+    public function testFindRecentOrdersForUserReturnsMostRecent(): void
+    {
+        $user = $this->createUser('buyer@example.com');
+        $this->createOrder('ORD-1001', $user, new DateTimeImmutable('2024-01-01 10:00:00'));
+        $recent = $this->createOrder('ORD-1002', $user, new DateTimeImmutable('2024-01-05 12:00:00'));
+
+        $this->entityManager->flush();
+
+        $results = $this->repository->findRecentOrdersForUser($user, 1);
+
+        self::assertCount(1, $results);
+        self::assertSame($recent->getId(), $results[0]->getId());
+    }
+
+    public function testFindOrdersForGuestEmailReturnsOrders(): void
+    {
+        $this->createGuestOrder('guest@example.com');
+        $this->createGuestOrder('guest@example.com');
+        $this->createGuestOrder('other@example.com');
+
+        $results = $this->repository->findOrdersForGuestEmail('guest@example.com', 5);
+
+        self::assertCount(2, $results);
+        foreach ($results as $order) {
+            self::assertTrue($order->isGuestOrder());
+        }
+    }
+
+    public function testFindOpenOrdersExcludesCompletedStatuses(): void
+    {
+        $user = $this->createUser('buyer@example.com');
+        $open = $this->createOrder('ORD-2001', $user);
+        $completed = $this->createOrder('ORD-2002', $user);
+        $completed->setStatus(Order::STATUS_DELIVERED);
+        $this->entityManager->flush();
+
+        $results = $this->repository->findOpenOrders();
+
+        self::assertCount(1, $results);
+        self::assertSame($open->getId(), $results[0]->getId());
+    }
+
+    private function createUser(string $email): User
+    {
+        $user = new User(new Email($email), new PersonName('Test', 'User'), '', 'hash');
+        $user->setRoles(['ROLE_USER']);
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+
+    private function createOrder(
+        string $orderNumber,
+        ?User $user = null,
+        ?DateTimeImmutable $createdAt = null
+    ): Order {
+        $order = new Order(new OrderNumber($orderNumber));
+
+        if ($user !== null) {
+            $order->setCustomer($user);
+        }
+
+        $order->setSubtotal(new Money('100.00'))
+            ->setTaxAmount(new Money('10.00'))
+            ->setShippingAmount(new Money('5.00'))
+            ->setDiscountAmount(Money::zero())
+            ->calculateTotal()
+            ->setStatus(Order::STATUS_PENDING);
+
+        if ($createdAt !== null) {
+            $order->setCreatedAt($createdAt);
+            $order->setUpdatedAt($createdAt);
+        }
+
+        $this->entityManager->persist($order);
+
+        return $order;
+    }
+
+    private function createGuestOrder(string $email): Order
+    {
+        $order = $this->createOrder('ORD-' . random_int(3000, 3999));
+        $order->setCustomer(null);
+        $order->setGuestEmail(new Email($email));
+        $order->setGuestName(new PersonName('Guest', 'Customer'));
+        $this->entityManager->flush();
+
+        return $order;
+    }
+}

--- a/tests/Integration/Repository/ProductRepositoryTest.php
+++ b/tests/Integration/Repository/ProductRepositoryTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Domain\Entity\Category;
+use App\Domain\Entity\Product;
+use App\Domain\ValueObject\Money;
+use App\Domain\ValueObject\Slug;
+use App\Infrastructure\Repository\ProductRepository;
+use App\Tests\Support\Doctrine\DoctrineRepositoryTestCase;
+
+final class ProductRepositoryTest extends DoctrineRepositoryTestCase
+{
+    private ProductRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ProductRepository($this->managerRegistry);
+    }
+
+    protected function schemaClasses(): array
+    {
+        return [
+            Category::class,
+            Product::class,
+        ];
+    }
+
+    public function testSearchProductsMatchesTerm(): void
+    {
+        $electronics = $this->createCategory('Electronics', 'electronics');
+        $this->createProduct('Gaming Laptop', 'gaming-laptop', $electronics);
+        $this->createProduct('Office Chair', 'office-chair', $electronics);
+
+        $results = $this->repository->searchProducts('laptop', null, 1, 10);
+
+        self::assertCount(1, $results);
+        self::assertSame('Gaming Laptop', $results[0]->getName());
+    }
+
+    public function testSearchProductsFiltersByCategory(): void
+    {
+        $electronics = $this->createCategory('Electronics', 'electronics');
+        $furniture = $this->createCategory('Furniture', 'furniture');
+
+        $this->createProduct('Gaming Laptop', 'gaming-laptop', $electronics);
+        $this->createProduct('Office Chair', 'office-chair', $furniture);
+
+        $results = $this->repository->searchProducts(null, 'electronics', 1, 10);
+
+        self::assertCount(1, $results);
+        self::assertSame('Gaming Laptop', $results[0]->getName());
+    }
+
+    public function testSearchProductsAppliesPagination(): void
+    {
+        $category = $this->createCategory('Electronics', 'electronics');
+
+        $this->createProduct('Product A', 'product-a', $category, '100.00');
+        $this->createProduct('Product B', 'product-b', $category, '101.00');
+        $this->createProduct('Product C', 'product-c', $category, '102.00');
+
+        $results = $this->repository->searchProducts(null, null, 2, 2);
+
+        self::assertCount(1, $results);
+        self::assertInstanceOf(Product::class, $results[0]);
+    }
+
+    public function testCountSearchResultsReturnsTotal(): void
+    {
+        $category = $this->createCategory('Electronics', 'electronics');
+        $this->createProduct('Gaming Laptop', 'gaming-laptop', $category);
+        $this->createProduct('Gaming Mouse', 'gaming-mouse', $category);
+
+        $count = $this->repository->countSearchResults('gaming', null);
+
+        self::assertSame(2, $count);
+    }
+
+    public function testFindFeaturedProductsReturnsActiveFeatured(): void
+    {
+        $category = $this->createCategory('Electronics', 'electronics');
+
+        $featured = $this->createProduct('Featured', 'featured', $category);
+        $featured->setIsFeatured(true);
+
+        $inactive = $this->createProduct('Inactive', 'inactive', $category);
+        $inactive->setIsFeatured(true);
+        $inactive->setIsActive(false);
+
+        $results = $this->repository->findFeaturedProducts(5);
+
+        self::assertCount(1, $results);
+        self::assertSame('Featured', $results[0]->getName());
+    }
+
+    private function createCategory(string $name, string $slug): Category
+    {
+        $category = new Category($name, new Slug($slug));
+        $category->setDescription('Test category');
+
+        $this->entityManager->persist($category);
+        $this->entityManager->flush();
+
+        return $category;
+    }
+
+    private function createProduct(
+        string $name,
+        string $slug,
+        Category $category,
+        string $price = '99.99'
+    ): Product {
+        $product = new Product($name, new Slug($slug), new Money($price), $category);
+        $product->setShortDescription('Short description');
+
+        $this->entityManager->persist($product);
+        $this->entityManager->flush();
+
+        return $product;
+    }
+}

--- a/tests/Integration/Repository/UserRepositoryTest.php
+++ b/tests/Integration/Repository/UserRepositoryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Domain\Entity\User;
+use App\Domain\ValueObject\Email;
+use App\Domain\ValueObject\PersonName;
+use App\Infrastructure\Repository\UserRepository;
+use App\Tests\Support\Doctrine\DoctrineRepositoryTestCase;
+
+final class UserRepositoryTest extends DoctrineRepositoryTestCase
+{
+    private UserRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new UserRepository($this->managerRegistry);
+    }
+
+    protected function schemaClasses(): array
+    {
+        return [User::class];
+    }
+
+    public function testFindActiveUserByEmailReturnsUser(): void
+    {
+        $user = $this->createUser('active@example.com');
+
+        $found = $this->repository->findActiveUserByEmail('active@example.com');
+
+        self::assertNotNull($found);
+        self::assertSame($user->getId(), $found->getId());
+    }
+
+    public function testFindActiveUserByEmailIgnoresInactive(): void
+    {
+        $this->createUser('inactive@example.com', active: false);
+
+        $found = $this->repository->findActiveUserByEmail('inactive@example.com');
+
+        self::assertNull($found);
+    }
+
+    public function testSearchCustomersFiltersByTerm(): void
+    {
+        $this->createUser('john@example.com', firstName: 'John', lastName: 'Smith');
+        $this->createUser('jane@example.com', firstName: 'Jane', lastName: 'Doe');
+
+        $results = $this->repository->searchCustomers('smith', 10);
+
+        self::assertCount(1, $results);
+        self::assertSame('john@example.com', $results[0]->getEmail()->getValue());
+    }
+
+    public function testFindAdminsReturnsOnlyActiveAdmins(): void
+    {
+        $admin = $this->createUser('admin@example.com', roles: ['ROLE_ADMIN']);
+        $this->createUser('inactive-admin@example.com', roles: ['ROLE_ADMIN'], active: false);
+        $this->createUser('user@example.com');
+
+        $results = $this->repository->findAdmins();
+
+        self::assertCount(1, $results);
+        self::assertSame($admin->getId(), $results[0]->getId());
+    }
+
+    private function createUser(
+        string $email,
+        string $firstName = 'Test',
+        string $lastName = 'User',
+        array $roles = ['ROLE_USER'],
+        bool $active = true
+    ): User {
+        $user = new User(new Email($email), new PersonName($firstName, $lastName), '', 'hash');
+        $user->setRoles($roles);
+        $user->setIsActive($active);
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/tests/Support/Doctrine/DoctrineRepositoryTestCase.php
+++ b/tests/Support/Doctrine/DoctrineRepositoryTestCase.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\TestCase;
+
+abstract class DoctrineRepositoryTestCase extends TestCase
+{
+    protected EntityManagerInterface $entityManager;
+
+    protected InMemoryManagerRegistry $managerRegistry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->entityManager = TestEntityManagerFactory::create();
+        $this->managerRegistry = new InMemoryManagerRegistry($this->entityManager);
+
+        $schemaTool = new SchemaTool($this->entityManager);
+        $metadata = [];
+
+        foreach ($this->schemaClasses() as $class) {
+            $metadata[] = $this->entityManager->getClassMetadata($class);
+        }
+
+        if ($metadata !== []) {
+            $schemaTool->dropDatabase();
+            $schemaTool->createSchema($metadata);
+        }
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    abstract protected function schemaClasses(): array;
+
+    protected function tearDown(): void
+    {
+        if (isset($this->entityManager)) {
+            $this->entityManager->close();
+        }
+
+        unset($this->entityManager, $this->managerRegistry);
+
+        parent::tearDown();
+    }
+}

--- a/tests/Support/Doctrine/InMemoryManagerRegistry.php
+++ b/tests/Support/Doctrine/InMemoryManagerRegistry.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+
+final class InMemoryManagerRegistry implements ManagerRegistry
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly string $managerName = 'default'
+    ) {
+    }
+
+    public function getDefaultConnectionName(): string
+    {
+        return 'default';
+    }
+
+    public function getConnection(?string $name = null): object
+    {
+        return $this->entityManager->getConnection();
+    }
+
+    public function getConnections(): array
+    {
+        return ['default' => $this->getConnection()];
+    }
+
+    public function getConnectionNames(): array
+    {
+        return ['default' => 'default'];
+    }
+
+    public function getDefaultManagerName(): string
+    {
+        return $this->managerName;
+    }
+
+    public function getManager(?string $name = null): ObjectManager
+    {
+        return $this->entityManager;
+    }
+
+    public function getManagers(): array
+    {
+        return [$this->managerName => $this->entityManager];
+    }
+
+    public function resetManager(?string $name = null): ObjectManager
+    {
+        $this->entityManager->clear();
+        return $this->entityManager;
+    }
+
+    public function getManagerNames(): array
+    {
+        return [$this->managerName => $this->managerName];
+    }
+
+    public function getRepository(string $persistentObject, ?string $persistentManagerName = null)
+    {
+        return $this->entityManager->getRepository($persistentObject);
+    }
+
+    public function getManagerForClass(string $class): ?ObjectManager
+    {
+        return $this->entityManager;
+    }
+}

--- a/tests/Support/Doctrine/TestEntityManagerFactory.php
+++ b/tests/Support/Doctrine/TestEntityManagerFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support\Doctrine;
+
+use App\Domain\Type\EmailType as DomainEmailType;
+use App\Domain\Type\JsonbType;
+use App\Domain\Type\UuidType;
+use App\Infrastructure\Doctrine\Type\AddressType;
+use App\Infrastructure\Doctrine\Type\MoneyType;
+use App\Infrastructure\Doctrine\Type\OrderNumberType;
+use App\Infrastructure\Doctrine\Type\PhoneType;
+use App\Infrastructure\Doctrine\Type\ProductSkuType;
+use App\Infrastructure\Doctrine\Type\SlugType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
+
+final class TestEntityManagerFactory
+{
+    /**
+     * @param list<string> $extraEntityPaths
+     */
+    public static function create(array $extraEntityPaths = []): EntityManagerInterface
+    {
+        self::registerTypes();
+
+        $entityPaths = array_merge([
+            __DIR__ . '/../../../src/Domain/Entity',
+        ], $extraEntityPaths);
+
+        $config = ORMSetup::createAttributeMetadataConfiguration($entityPaths, true);
+
+        $entityManager = EntityManager::create([
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ], $config);
+
+        $platform = $entityManager->getConnection()->getDatabasePlatform();
+
+        foreach (array_keys(self::customTypes()) as $name) {
+            if (method_exists($platform, 'registerDoctrineTypeMapping')) {
+                $platform->registerDoctrineTypeMapping($name, $name);
+            }
+        }
+
+        return $entityManager;
+    }
+
+    /**
+     * @return array<string, class-string<Type>>
+     */
+    private static function customTypes(): array
+    {
+        return [
+            JsonbType::NAME => JsonbType::class,
+            UuidType::NAME => UuidType::class,
+            DomainEmailType::NAME => DomainEmailType::class,
+            MoneyType::NAME => MoneyType::class,
+            ProductSkuType::NAME => ProductSkuType::class,
+            SlugType::NAME => SlugType::class,
+            AddressType::NAME => AddressType::class,
+            OrderNumberType::NAME => OrderNumberType::class,
+            PhoneType::NAME => PhoneType::class,
+        ];
+    }
+
+    private static function registerTypes(): void
+    {
+        foreach (self::customTypes() as $name => $class) {
+            if (Type::hasType($name)) {
+                Type::overrideType($name, $class);
+            } else {
+                Type::addType($name, $class);
+            }
+        }
+    }
+}

--- a/tests/Unit/Domain/Entity/OrderTest.php
+++ b/tests/Unit/Domain/Entity/OrderTest.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Domain\Entity;
 
+use App\Domain\Entity\Category;
 use App\Domain\Entity\Order;
 use App\Domain\Entity\OrderItem;
 use App\Domain\Entity\Payment;
 use App\Domain\Entity\Product;
 use App\Domain\Entity\User;
-use App\Domain\Entity\Category;
 use App\Domain\ValueObject\Address;
 use App\Domain\ValueObject\Email;
 use App\Domain\ValueObject\Money;
 use App\Domain\ValueObject\OrderNumber;
 use App\Domain\ValueObject\PersonName;
 use App\Domain\ValueObject\Phone;
+use App\Domain\ValueObject\Slug;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -219,8 +220,8 @@ final class OrderTest extends TestCase
 
     public function testOrderItemsManagement(): void
     {
-        $category = new Category('Electronics', 'electronics');
-        $product = new Product('Test Product', 'test-product', '99.99', $category);
+        $category = new Category('Electronics', Slug::fromString('electronics'));
+        $product = new Product('Test Product', Slug::fromString('test-product'), new Money('99.99'), $category);
         $orderItem = new OrderItem($product, 2);
 
         self::assertSame(0, $this->order->getItemsCount());
@@ -256,11 +257,11 @@ final class OrderTest extends TestCase
     public function testOrderValidation(): void
     {
         // Test valid order
-        $this->order->setGuestEmail('test@example.com');
+        $this->order->setGuestEmail(new Email('test@example.com'));
         $this->order->setGuestFirstName('John');
         $this->order->setGuestLastName('Doe');
-        $this->order->setSubtotal('100.00');
-        $this->order->setTotal('100.00');
+        $this->order->setSubtotal(new Money('100.00'));
+        $this->order->setTotal(new Money('100.00'));
 
         self::assertTrue($this->order->isValid());
         self::assertEmpty($this->order->getValidationErrors());

--- a/tests/Unit/Domain/Entity/PaymentTest.php
+++ b/tests/Unit/Domain/Entity/PaymentTest.php
@@ -32,12 +32,12 @@ final class PaymentTest extends TestCase
     {
         self::assertSame($this->order, $this->payment->getOrder());
         self::assertSame('pi_test123456789', $this->payment->getStripePaymentIntentId());
-        self::assertSame('100.00', $this->payment->getAmount());
+        self::assertSame('100.00', $this->payment->getAmount()->getAmount());
         self::assertSame(100.0, $this->payment->getAmountAsFloat());
         self::assertSame(10000, $this->payment->getAmountInCents());
         self::assertSame('USD', $this->payment->getCurrency());
         self::assertSame(Payment::STATUS_PENDING, $this->payment->getStatus());
-        self::assertSame('0.00', $this->payment->getRefundedAmount());
+        self::assertSame('0.00', $this->payment->getRefundedAmount()->getAmount());
         self::assertTrue($this->payment->isPending());
     }
 
@@ -167,7 +167,7 @@ final class PaymentTest extends TestCase
         $this->payment->setStatus(Payment::STATUS_SUCCEEDED);
         
         self::assertSame(0.0, $this->payment->getRefundedAmountAsFloat());
-        self::assertSame(100.0, $this->payment->getRemainingAmount());
+        self::assertSame(100.0, $this->payment->getRemainingAmount()->getAmountAsFloat());
         self::assertFalse($this->payment->isFullyRefunded());
         self::assertFalse($this->payment->isPartiallyRefunded());
         self::assertTrue($this->payment->canBeRefunded());
@@ -175,9 +175,9 @@ final class PaymentTest extends TestCase
         // Add partial refund
         $this->payment->addRefund('30.00');
         
-        self::assertSame('30.00', $this->payment->getRefundedAmount());
+        self::assertSame('30.00', $this->payment->getRefundedAmount()->getAmount());
         self::assertSame(30.0, $this->payment->getRefundedAmountAsFloat());
-        self::assertSame(70.0, $this->payment->getRemainingAmount());
+        self::assertSame(70.0, $this->payment->getRemainingAmount()->getAmountAsFloat());
         self::assertFalse($this->payment->isFullyRefunded());
         self::assertTrue($this->payment->isPartiallyRefunded());
         self::assertTrue($this->payment->isPartiallyRefundedStatus());
@@ -186,8 +186,8 @@ final class PaymentTest extends TestCase
         // Add full refund
         $this->payment->addRefund('70.00');
         
-        self::assertSame('100.00', $this->payment->getRefundedAmount());
-        self::assertSame(0.0, $this->payment->getRemainingAmount());
+        self::assertSame('100.00', $this->payment->getRefundedAmount()->getAmount());
+        self::assertSame(0.0, $this->payment->getRemainingAmount()->getAmountAsFloat());
         self::assertTrue($this->payment->isFullyRefunded());
         self::assertFalse($this->payment->isPartiallyRefunded());
         self::assertTrue($this->payment->isRefunded());
@@ -210,8 +210,8 @@ final class PaymentTest extends TestCase
         $this->payment->addRefund('25.00');
         $this->payment->addRefund('25.00');
         
-        self::assertSame('75.00', $this->payment->getRefundedAmount());
-        self::assertSame(25.0, $this->payment->getRemainingAmount());
+        self::assertSame('75.00', $this->payment->getRefundedAmount()->getAmount());
+        self::assertSame(25.0, $this->payment->getRemainingAmount()->getAmountAsFloat());
         self::assertTrue($this->payment->isPartiallyRefunded());
     }
 
@@ -242,10 +242,10 @@ final class PaymentTest extends TestCase
 
     public function testPaymentToString(): void
     {
-        self::assertSame('Payment pi_test123456789 - 100.00 USD', (string) $this->payment);
+        self::assertSame('Payment pi_test123456789 - $100.00', (string) $this->payment);
         
         $this->payment->setCurrency('EUR');
-        self::assertSame('Payment pi_test123456789 - 100.00 EUR', (string) $this->payment);
+        self::assertSame('Payment pi_test123456789 - €100.00', (string) $this->payment);
     }
 
     public function testStripeCustomerIdHandling(): void

--- a/tests/Unit/Domain/Entity/UserTest.php
+++ b/tests/Unit/Domain/Entity/UserTest.php
@@ -220,31 +220,26 @@ final class UserTest extends TestCase
 
     public function testValidationWithInvalidEmail(): void
     {
-        $user = new User(
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid email format');
+
+        new User(
             'invalid-email',
             'John',
             'Doe'
         );
-        
-        self::assertFalse($user->isValid());
-        
-        $errors = $user->getValidationErrors();
-        self::assertArrayHasKey('email', $errors);
     }
 
     public function testValidationWithEmptyNames(): void
     {
-        $user = new User(
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('First name cannot be empty');
+
+        new User(
             'test@example.com',
             '',
             ''
         );
-        
-        self::assertFalse($user->isValid());
-        
-        $errors = $user->getValidationErrors();
-        self::assertArrayHasKey('firstName', $errors);
-        self::assertArrayHasKey('lastName', $errors);
     }
 
     public function testEraseCredentials(): void

--- a/tests/Unit/Infrastructure/Repository/AbstractRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repository/AbstractRepositoryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Repository;
+
+use App\Domain\Entity\Category;
+use App\Domain\ValueObject\Slug;
+use App\Infrastructure\Repository\AbstractRepository;
+use App\Tests\Support\Doctrine\DoctrineRepositoryTestCase;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class AbstractRepositoryTest extends DoctrineRepositoryTestCase
+{
+    private CategoryRepositoryStub $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new CategoryRepositoryStub($this->managerRegistry);
+    }
+
+    protected function schemaClasses(): array
+    {
+        return [
+            Category::class,
+        ];
+    }
+
+    public function testSavePersistsEntity(): void
+    {
+        $category = new Category('Electronics', new Slug('electronics'));
+
+        $this->repository->save($category);
+
+        self::assertNotNull($category->getId());
+
+        $reloaded = $this->repository->find($category->getId());
+        self::assertSame('Electronics', $reloaded->getName());
+    }
+
+    public function testFindByCriteriaReturnsMatchingEntities(): void
+    {
+        $active = new Category('Active', new Slug('active'));
+        $active->setIsActive(true);
+        $inactive = new Category('Inactive', new Slug('inactive'));
+        $inactive->setIsActive(false);
+
+        $this->repository->save($active);
+        $this->repository->save($inactive);
+
+        $results = $this->repository->exposeFindByCriteria(['isActive' => true]);
+
+        self::assertCount(1, $results);
+        self::assertSame('Active', $results[0]->getName());
+    }
+
+    public function testFindOneByCriteriaReturnsSingleEntity(): void
+    {
+        $category = new Category('Gear', new Slug('gear'));
+        $this->repository->save($category);
+
+        $found = $this->repository->exposeFindOneByCriteria(['slug' => new Slug('gear')]);
+
+        self::assertNotNull($found);
+        self::assertSame('Gear', $found->getName());
+    }
+
+    public function testRemoveDeletesEntity(): void
+    {
+        $category = new Category('Temporary', new Slug('temporary'));
+        $this->repository->save($category);
+
+        $categoryId = $category->getId();
+
+        $this->repository->remove($category);
+
+        self::assertNotNull($categoryId);
+        self::assertNull($this->repository->find($categoryId));
+    }
+}
+
+/** @extends AbstractRepository<Category> */
+final class CategoryRepositoryStub extends AbstractRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Category::class);
+    }
+
+    /** @return list<Category> */
+    public function exposeFindByCriteria(array $criteria): array
+    {
+        return $this->findByCriteria($criteria);
+    }
+
+    public function exposeFindOneByCriteria(array $criteria): ?Category
+    {
+        return $this->findOneByCriteria($criteria);
+    }
+}


### PR DESCRIPTION
- create domain repository interfaces for products, orders, and users
- implement Doctrine repositories with shared abstract base helpers
- wire repositories on entities, add SQLite-friendly type declarations
- add unit/integration tests with in-memory EntityManager + value object fixes
- refresh AGENTS.md contributor guide for repository usage